### PR TITLE
Fix: Synchronize Watch App version with iOS App version

### DIFF
--- a/Trio Watch App/Info.plist
+++ b/Trio Watch App/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleShortVersionString</key>
+	<string>$(APP_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(APP_BUILD_NUMBER)</string>
 	<key>EXAppExtensionAttributes</key>
 	<dict>
 		<key>EXExtensionPointIdentifier</key>


### PR DESCRIPTION
The CFBundleShortVersionString for the WatchOS app was not set, causing it to default to "1.0" and mismatch with the iOS app's version ("0.5.0") during Xcode Cloud builds.

This change updates the "Trio Watch App/Info.plist" to include:
- CFBundleShortVersionString: set to $(APP_VERSION)
- CFBundleVersion: set to $(APP_BUILD_NUMBER)

This ensures the Watch App's versioning is derived from the shared Config.xcconfig file, consistent with the main iOS application.