### PR TITLE
feat: Display latest dev version in Settings for non-main builds

### DIFF
--- a/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -9,6 +9,8 @@ extension Settings {
         var latestVersion: String?
         var isUpdateAvailable: Bool
         var isBlacklisted: Bool
+        var latestDevVersion: String?
+        var isDevUpdateAvailable: Bool
     }
 
     struct RootView: BaseView {
@@ -27,7 +29,9 @@ extension Settings {
         @State private var versionInfo = VersionInfo(
             latestVersion: nil,
             isUpdateAvailable: false,
-            isBlacklisted: false
+            isBlacklisted: false,
+            latestDevVersion: nil,
+            isDevUpdateAvailable: false
         )
         @State private var closedLoopDisabled = true
 
@@ -40,12 +44,13 @@ extension Settings {
         }
 
         @ViewBuilder var versionInfoView: some View {
-            let latestVersion = versionInfo.latestVersion
-            if let version = latestVersion {
-                let updateColor: Color = versionInfo.isUpdateAvailable ? .orange : .green
-                let versionIconName = versionInfo.isUpdateAvailable ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"
+            VStack(alignment: .leading, spacing: 4) {
+                // Main version info
+                if let version = versionInfo.latestVersion {
+                    let updateColor: Color = versionInfo.isUpdateAvailable ? .orange : .green
+                    let versionIconName = versionInfo
+                        .isUpdateAvailable ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"
 
-                VStack(alignment: .leading, spacing: 4) {
                     HStack {
                         Text("Latest version: \(version)")
                             .font(.footnote)
@@ -62,11 +67,33 @@ extension Settings {
                                 .foregroundColor(.red)
                         }
                     }
+                } else {
+                    Text("Latest version: Fetching...")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
                 }
-            } else {
-                Text("Latest version: Fetching...")
-                    .font(.footnote)
-                    .foregroundColor(.secondary)
+
+                // Show latest dev version on any branch except main
+                let buildDetails = BuildDetails.shared
+                if buildDetails.trioBranch != "main" {
+                    if let devVersion = versionInfo.latestDevVersion {
+                        let devUpdateColor: Color = versionInfo.isDevUpdateAvailable ? .orange : .secondary
+                        let devVersionIconName = versionInfo.isDevUpdateAvailable ? "arrow.up.circle.fill" : "hammer.fill"
+
+                        HStack {
+                            Text("Latest dev: \(devVersion)")
+                                .font(.footnote)
+                                .foregroundColor(devUpdateColor)
+                            Image(systemName: devVersionIconName)
+                                .font(.footnote)
+                                .foregroundColor(devUpdateColor)
+                        }
+                    } else {
+                        Text("Latest dev: Fetching...")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
+                }
             }
         }
 
@@ -367,13 +394,21 @@ extension Settings {
             .screenNavigation(self)
             .onAppear {
                 AppVersionChecker.shared.refreshVersionInfo { _, latestVersion, isNewer, isBlacklisted in
-                    let updateAvailable = isNewer
                     DispatchQueue.main.async {
-                        versionInfo = VersionInfo(
-                            latestVersion: latestVersion,
-                            isUpdateAvailable: updateAvailable,
-                            isBlacklisted: isBlacklisted
-                        )
+                        versionInfo.latestVersion = latestVersion
+                        versionInfo.isUpdateAvailable = isNewer
+                        versionInfo.isBlacklisted = isBlacklisted
+                    }
+                }
+
+                // Fetch dev version if not on main branch
+                let buildDetails = BuildDetails.shared
+                if buildDetails.trioBranch != "main" {
+                    AppVersionChecker.shared.checkForNewDevVersion { devVersion, isDevNewer in
+                        DispatchQueue.main.async {
+                            versionInfo.latestDevVersion = devVersion
+                            versionInfo.isDevUpdateAvailable = isDevNewer
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds display of latest dev version (x.x.x.x format) in Settings for all non-main branch builds
- Shows visual indicators for update status using same logic as main version display
- Fetches APP_DEV_VERSION from GitHub dev branch Config.xcconfig

## Screenshots

### Dev Branch Builds
| When on latest dev version | When newer dev version available |
|----------------------------|----------------------------------|
| ![image](https://github.com/user-attachments/assets/698f8def-b303-4ae7-af97-766cae7c84da) | ![image](https://github.com/user-attachments/assets/1315a9e6-b521-45ee-9bb8-986039d84f01) |
| Gray hammer icon indicates current version | Orange arrow icon indicates update available |

### Main Branch Build
| When on main branch |
|---------------------|
| ![image](https://github.com/user-attachments/assets/48decfa8-40f4-4455-b568-64eee0c1f882) |
| Dev version row is hidden - only shows main app version |

## Changes
- Extended `AppVersionChecker` to fetch and parse APP_DEV_VERSION (instead of APP_VERSION)
- Added dev version checking with same 24-hour caching logic as main version
- Updated Settings UI to conditionally show dev version on non-main branches
- Visual feedback: Orange with arrow icon for updates, gray with hammer icon when current

## Implementation Details
- Only appears when `BuildDetails.trioBranch != "main"`
- Compares against current app's dev version (from Info.plist AppDevVersion)
- Uses separate parsing method to distinguish APP_DEV_VERSION from APP_VERSION
- Maintains separate cache for dev version checks

## Test Plan
- [x] Build from feature branch and verify dev version appears
- [x] Verify correct version format (0.5.0.x not 0.5.0)
- [x] Test visual indicators (orange/arrow when behind, gray/hammer when current)
- [x] Build from main branch and verify dev version does NOT appear
