### PR TITLE
Enable Critical Alerts (override Silent/Focus)

### DIFF
--- a/Trio/Resources/Trio.entitlements
+++ b/Trio/Resources/Trio.entitlements
@@ -14,6 +14,8 @@
 	<array>
 		<string>TAG</string>
 	</array>
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/Trio/Sources/Services/UserNotifications/UserNotificationsManager.swift
+++ b/Trio/Sources/Services/UserNotifications/UserNotificationsManager.swift
@@ -192,7 +192,7 @@ final class BaseUserNotificationsManager: NSObject, UserNotificationsManager, In
 
     func requestNotificationPermissions(completion: @escaping (Bool) -> Void) {
         debug(.service, "requestNotificationPermissions")
-        notificationCenter.requestAuthorization(options: [.badge, .sound, .alert]) { granted, error in
+        notificationCenter.requestAuthorization(options: [.badge, .sound, .alert, .criticalAlert]) { granted, error in
             if granted {
                 debug(.service, "requestNotificationPermissions was granted")
                 DispatchQueue.main.async {


### PR DESCRIPTION
Enables iOS **Critical Alerts** for Trio — the "Kritieke meldingen" toggle that lets alarms break through Silent mode and Focus, the same as Dexcom G7.

The alert refactor (PR #1203) already wired all the code (`DeviceAlertSeverity.critical` → `UNNotificationInterruptionLevel.critical`, `CriticalAlertAudioPlayer`, the critical audio `alarm.caf`). The only missing pieces were the **entitlement** and the **authorization request** — without them iOS silently downgrades `.critical` notifications and never shows the toggle.

## Commits
1. **`cbd5f5aa` — Request critical-alert authorization** *(build-safe)*
   Adds `.criticalAlert` to `requestAuthorization(options:)` in `UserNotificationsManager`. Harmless without the entitlement (iOS just won't grant it).
2. **`6cb1d374` — Add Critical Alerts entitlement** *(⚠️ gated)*
   Adds `com.apple.developer.usernotifications.critical-alerts` to `Trio.entitlements`.

## ⚠️ Do not build/merge commit 2 until Apple grants the entitlement
Critical Alerts is a **special-request** entitlement (unlike Time-Sensitive, you can't self-enable it):

1. Request it from Apple: **developer.apple.com → Support → "Request Critical Alerts entitlement"**, with a health/safety justification (DIY automated insulin delivery; glucose/pump alarms must override Silent & Focus).
2. Apple grants it to your **Team ID** and attaches it to the provisioning profile.
3. Enable the capability on the App ID, regenerate profiles, then build.

If commit 2 is built **before** the grant, managed/automatic signing will fail (no profile can carry an ungranted entitlement) — the same failure class as the time-sensitive issue, but unfixable until the grant exists. Until then, commit 1 alone is safe to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpcDkYHNDwWH5Ub6kdVh5g)_