### PR TITLE
fix(treatments): keep focused input visible above the keyboard (#1115)

### DIFF
--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -202,190 +202,225 @@ extension Treatments {
             }
         }
 
+        /// Scrolls the currently focused input row so it stays visible above the on-screen keyboard.
+        ///
+        /// The treatments list grows or shrinks depending on user settings (e.g. the Reduced Bolus /
+        /// Super Bolus toggles add an extra row), so relying on the system's default keyboard avoidance
+        /// is unreliable: on some devices/configurations the bolus field ends up hidden behind the
+        /// keyboard. Explicitly scrolling the focused row into view guarantees the user can always see
+        /// what they are entering, regardless of which optional rows are shown. See issue #1115.
+        ///
+        /// - Parameters:
+        ///   - field: The field that just gained focus, or `nil` when focus was cleared.
+        ///   - proxy: The enclosing `ScrollViewReader`'s proxy used to perform the scroll.
+        private func scrollFocusedFieldIntoView(_ field: FocusedField?, proxy: ScrollViewProxy) {
+            guard let field else { return }
+
+            // Fat and Protein share a single row, which is tagged with `.fat`.
+            let targetID: FocusedField = (field == .protein) ? .fat : field
+
+            // Delay slightly so the keyboard's presentation animation has begun and the List has
+            // resized its scrollable area before we scroll, otherwise the target can land back
+            // underneath the keyboard.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                withAnimation {
+                    proxy.scrollTo(targetID, anchor: .center)
+                }
+            }
+        }
+
         var body: some View {
             ZStack(alignment: .center) {
                 VStack {
-                    List {
-                        Section {
-                            ForecastChart(state: state)
-                                .padding(.vertical)
-                        }.listRowBackground(Color.chart)
+                    ScrollViewReader { proxy in
+                        List {
+                            Section {
+                                ForecastChart(state: state)
+                                    .padding(.vertical)
+                            }.listRowBackground(Color.chart)
 
-                        Section {
-                            carbsTextField()
+                            Section {
+                                carbsTextField()
+                                    .id(FocusedField.carbs)
 
-                            if state.useFPUconversion {
-                                proteinAndFat()
+                                if state.useFPUconversion {
+                                    proteinAndFat()
+                                        .id(FocusedField.fat)
 
-                                if showFatProteinOrderBanner {
+                                    if showFatProteinOrderBanner {
+                                        HStack {
+                                            Image(systemName: "arrow.left.arrow.right")
+                                            Text("The order of Fat and Protein inputs has changed.").font(.callout)
+                                            Spacer()
+                                            Button {
+                                                PropertyPersistentFlags.shared.hasSeenFatProteinOrderChange = true
+                                                withAnimation { showFatProteinOrderBanner = false }
+                                            } label: {
+                                                Image(systemName: "xmark.circle.fill")
+                                            }
+                                            .buttonStyle(.plain)
+                                        }
+                                        .listRowBackground(Color.orange.opacity(0.75))
+                                        .transition(.opacity)
+                                    }
+                                }
+
+                                // Time
+                                HStack {
+                                    // Semi-hacky workaround to make sure the List renders the horizontal divider properly between the `Time` and `Note` rows within the Section
                                     HStack {
-                                        Image(systemName: "arrow.left.arrow.right")
-                                        Text("The order of Fat and Protein inputs has changed.").font(.callout)
-                                        Spacer()
+                                        Text("")
+                                        Image(systemName: "clock").padding(.leading, -7)
+                                    }
+
+                                    Spacer()
+                                    if !pushed {
                                         Button {
-                                            PropertyPersistentFlags.shared.hasSeenFatProteinOrderChange = true
-                                            withAnimation { showFatProteinOrderBanner = false }
-                                        } label: {
-                                            Image(systemName: "xmark.circle.fill")
-                                        }
-                                        .buttonStyle(.plain)
-                                    }
-                                    .listRowBackground(Color.orange.opacity(0.75))
-                                    .transition(.opacity)
-                                }
-                            }
+                                            pushed = true
+                                        } label: { Text("Now") }.buttonStyle(.borderless).foregroundColor(.secondary)
+                                            .padding(.trailing, 5)
+                                    } else {
+                                        Button { state.date = state.date.addingTimeInterval(-15.minutes.timeInterval) }
+                                        label: { Image(systemName: "minus.circle") }.tint(.blue).buttonStyle(.borderless)
 
-                            // Time
-                            HStack {
-                                // Semi-hacky workaround to make sure the List renders the horizontal divider properly between the `Time` and `Note` rows within the Section
-                                HStack {
-                                    Text("")
-                                    Image(systemName: "clock").padding(.leading, -7)
-                                }
-
-                                Spacer()
-                                if !pushed {
-                                    Button {
-                                        pushed = true
-                                    } label: { Text("Now") }.buttonStyle(.borderless).foregroundColor(.secondary)
-                                        .padding(.trailing, 5)
-                                } else {
-                                    Button { state.date = state.date.addingTimeInterval(-15.minutes.timeInterval) }
-                                    label: { Image(systemName: "minus.circle") }.tint(.blue).buttonStyle(.borderless)
-
-                                    DatePicker(
-                                        "Time",
-                                        selection: $state.date,
-                                        displayedComponents: [.hourAndMinute]
-                                    ).controlSize(.mini)
-                                        .labelsHidden()
-                                        .onChange(of: state.date) { _, _ in
-                                            // Trigger simulation when date changes to update forecasts for backdated carbs
-                                            Task {
-                                                // `updateForecasts()` does update the `simulatedDetermination` of type `Determination?` var on the main thread, so I can use this to pass its cob value into the bolus calc manager
-                                                await state.updateForecasts()
-                                                state.insulinCalculated = await state.calculateInsulin()
+                                        DatePicker(
+                                            "Time",
+                                            selection: $state.date,
+                                            displayedComponents: [.hourAndMinute]
+                                        ).controlSize(.mini)
+                                            .labelsHidden()
+                                            .onChange(of: state.date) { _, _ in
+                                                // Trigger simulation when date changes to update forecasts for backdated carbs
+                                                Task {
+                                                    // `updateForecasts()` does update the `simulatedDetermination` of type `Determination?` var on the main thread, so I can use this to pass its cob value into the bolus calc manager
+                                                    await state.updateForecasts()
+                                                    state.insulinCalculated = await state.calculateInsulin()
+                                                }
                                             }
+                                        Button {
+                                            state.date = state.date.addingTimeInterval(15.minutes.timeInterval)
                                         }
-                                    Button {
-                                        state.date = state.date.addingTimeInterval(15.minutes.timeInterval)
+                                        label: { Image(systemName: "plus.circle") }.tint(.blue).buttonStyle(.borderless)
                                     }
-                                    label: { Image(systemName: "plus.circle") }.tint(.blue).buttonStyle(.borderless)
                                 }
-                            }
 
-                            // Notes
-                            HStack {
-                                Image(systemName: "square.and.pencil")
-                                TextFieldWithToolBarString(
-                                    text: $state.note,
-                                    placeholder: String(localized: "Note..."),
-                                    maxLength: 25
-                                )
-                            }
-                        }.listRowBackground(Color.chart)
+                                // Notes
+                                HStack {
+                                    Image(systemName: "square.and.pencil")
+                                    TextFieldWithToolBarString(
+                                        text: $state.note,
+                                        placeholder: String(localized: "Note..."),
+                                        maxLength: 25
+                                    )
+                                }
+                            }.listRowBackground(Color.chart)
 
-                        Section {
-                            if state.fattyMeals || state.sweetMeals {
-                                HStack(spacing: 10) {
-                                    if state.fattyMeals {
-                                        Toggle(isOn: $state.useFattyMealCorrectionFactor) {
-                                            Text("Reduced Bolus")
-                                        }
-                                        .toggleStyle(RadioButtonToggleStyle())
-                                        .font(.footnote)
-                                        .onChange(of: state.useFattyMealCorrectionFactor) {
-                                            Task {
-                                                state.insulinCalculated = await state.calculateInsulin()
-                                                if state.useFattyMealCorrectionFactor {
-                                                    state.useSuperBolus = false
+                            Section {
+                                if state.fattyMeals || state.sweetMeals {
+                                    HStack(spacing: 10) {
+                                        if state.fattyMeals {
+                                            Toggle(isOn: $state.useFattyMealCorrectionFactor) {
+                                                Text("Reduced Bolus")
+                                            }
+                                            .toggleStyle(RadioButtonToggleStyle())
+                                            .font(.footnote)
+                                            .onChange(of: state.useFattyMealCorrectionFactor) {
+                                                Task {
+                                                    state.insulinCalculated = await state.calculateInsulin()
+                                                    if state.useFattyMealCorrectionFactor {
+                                                        state.useSuperBolus = false
+                                                    }
                                                 }
                                             }
                                         }
-                                    }
-                                    if state.sweetMeals {
-                                        Toggle(isOn: $state.useSuperBolus) {
-                                            Text("Super Bolus")
-                                        }
-                                        .toggleStyle(RadioButtonToggleStyle())
-                                        .font(.footnote)
-                                        .onChange(of: state.useSuperBolus) {
-                                            Task {
-                                                state.insulinCalculated = await state.calculateInsulin()
-                                                if state.useSuperBolus {
-                                                    state.useFattyMealCorrectionFactor = false
+                                        if state.sweetMeals {
+                                            Toggle(isOn: $state.useSuperBolus) {
+                                                Text("Super Bolus")
+                                            }
+                                            .toggleStyle(RadioButtonToggleStyle())
+                                            .font(.footnote)
+                                            .onChange(of: state.useSuperBolus) {
+                                                Task {
+                                                    state.insulinCalculated = await state.calculateInsulin()
+                                                    if state.useSuperBolus {
+                                                        state.useFattyMealCorrectionFactor = false
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 }
-                            }
 
-                            HStack {
                                 HStack {
-                                    Text("Recommendation")
-                                    Button(action: {
-                                        state.showInfo.toggle()
-                                    }, label: {
-                                        Image(systemName: "info.circle")
-                                    })
-                                        .foregroundStyle(.blue)
-                                        .buttonStyle(PlainButtonStyle())
-                                }
-                                Spacer()
-                                Button {
-                                    state.amount = state.insulinCalculated
-                                } label: {
                                     HStack {
-                                        Text(
-                                            formatter
-                                                .string(from: Double(state.insulinCalculated) as NSNumber) ?? ""
-                                        )
-
-                                        Text(
-                                            String(
-                                                localized:
-                                                " U",
-                                                comment: "Unit in number of units delivered (keep the space character!)"
-                                            )
-                                        ).foregroundColor(.secondary)
+                                        Text("Recommendation")
+                                        Button(action: {
+                                            state.showInfo.toggle()
+                                        }, label: {
+                                            Image(systemName: "info.circle")
+                                        })
+                                            .foregroundStyle(.blue)
+                                            .buttonStyle(PlainButtonStyle())
                                     }
-                                }
-                                .disabled(state.insulinCalculated == 0 || state.amount == state.insulinCalculated)
-                                .buttonStyle(.bordered).padding(.trailing, -10)
-                            }
+                                    Spacer()
+                                    Button {
+                                        state.amount = state.insulinCalculated
+                                    } label: {
+                                        HStack {
+                                            Text(
+                                                formatter
+                                                    .string(from: Double(state.insulinCalculated) as NSNumber) ?? ""
+                                            )
 
-                            HStack {
-                                Text("Bolus")
-                                Spacer()
-                                TextFieldWithToolBar(
-                                    text: $state.amount,
-                                    placeholder: "0",
-                                    textColor: colorScheme == .dark ? .white : .blue,
-                                    maxLength: 5,
-                                    numberFormatter: formatter,
-                                    showArrows: true,
-                                    previousTextField: { focusedField = previousField(from: .bolus) },
-                                    nextTextField: { focusedField = nextField(from: .bolus) },
-                                    unitsText: String(localized: "U", comment: "Units for bolus amount")
-                                ).focused($focusedField, equals: .bolus)
-                                    .onChange(of: state.amount) {
-                                        Task {
-                                            await state.updateForecasts()
+                                            Text(
+                                                String(
+                                                    localized:
+                                                    " U",
+                                                    comment: "Unit in number of units delivered (keep the space character!)"
+                                                )
+                                            ).foregroundColor(.secondary)
                                         }
                                     }
-                            }
+                                    .disabled(state.insulinCalculated == 0 || state.amount == state.insulinCalculated)
+                                    .buttonStyle(.bordered).padding(.trailing, -10)
+                                }
 
-                            HStack {
-                                Text("External Insulin")
-                                Spacer()
-                                Toggle("", isOn: $state.externalInsulin).toggleStyle(CheckboxToggleStyle())
-                            }
-                        }.listRowBackground(Color.chart)
+                                HStack {
+                                    Text("Bolus")
+                                    Spacer()
+                                    TextFieldWithToolBar(
+                                        text: $state.amount,
+                                        placeholder: "0",
+                                        textColor: colorScheme == .dark ? .white : .blue,
+                                        maxLength: 5,
+                                        numberFormatter: formatter,
+                                        showArrows: true,
+                                        previousTextField: { focusedField = previousField(from: .bolus) },
+                                        nextTextField: { focusedField = nextField(from: .bolus) },
+                                        unitsText: String(localized: "U", comment: "Units for bolus amount")
+                                    ).focused($focusedField, equals: .bolus)
+                                        .onChange(of: state.amount) {
+                                            Task {
+                                                await state.updateForecasts()
+                                            }
+                                        }
+                                }
+                                .id(FocusedField.bolus)
 
-                        treatmentButton
+                                HStack {
+                                    Text("External Insulin")
+                                    Spacer()
+                                    Toggle("", isOn: $state.externalInsulin).toggleStyle(CheckboxToggleStyle())
+                                }
+                            }.listRowBackground(Color.chart)
+
+                            treatmentButton
+                        }
+                        .listSectionSpacing(sectionSpacing)
+                        .onChange(of: focusedField) { _, newValue in
+                            scrollFocusedFieldIntoView(newValue, proxy: proxy)
+                        }
                     }
-                    .listSectionSpacing(sectionSpacing)
                 }
                 .blur(radius: state.isAwaitingDeterminationResult ? 5 : 0)
 

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -223,14 +223,13 @@ extension Treatments {
             // resized its scrollable area before we scroll, otherwise the target can land back
             // underneath the keyboard.
             //
-            // Anchor `.bottom`: the List shrinks its scrollable area to avoid the keyboard, so a
-            // bottom anchor parks the focused input row just above the keyboard. For the Bolus field
-            // this intentionally leaves the "Enact Bolus" button hidden behind the keyboard, so the
-            // user has to dismiss the keyboard and take a second look at the entered amount before
-            // they can tap it — a deliberate safety nudge (see issue #1115 discussion).
+            // Anchor `.center`: a `.bottom` anchor tucks the row behind the keyboard's accessory
+            // toolbar (the trash / chevron / done bar), because the List's keyboard inset doesn't
+            // account for that bar's height. Centring the focused row in the remaining visible area
+            // reliably keeps the whole input clear of both the keyboard and its toolbar. See #1115.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 withAnimation {
-                    proxy.scrollTo(targetID, anchor: .bottom)
+                    proxy.scrollTo(targetID, anchor: .center)
                 }
             }
         }

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -222,9 +222,15 @@ extension Treatments {
             // Delay slightly so the keyboard's presentation animation has begun and the List has
             // resized its scrollable area before we scroll, otherwise the target can land back
             // underneath the keyboard.
+            //
+            // Anchor `.bottom`: the List shrinks its scrollable area to avoid the keyboard, so a
+            // bottom anchor parks the focused input row just above the keyboard. For the Bolus field
+            // this intentionally leaves the "Enact Bolus" button hidden behind the keyboard, so the
+            // user has to dismiss the keyboard and take a second look at the entered amount before
+            // they can tap it — a deliberate safety nudge (see issue #1115 discussion).
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 withAnimation {
-                    proxy.scrollTo(targetID, anchor: .center)
+                    proxy.scrollTo(targetID, anchor: .bottom)
                 }
             }
         }


### PR DESCRIPTION
## Summary

Addresses nightscout/Trio#1115 — on the Treatments screen the bolus entry field can be hidden behind the on-screen keyboard, so a user can type `11` instead of `1` without seeing it (a safety concern for insulin dosing).

The system's default keyboard avoidance is unreliable here: the list height changes with user settings (the **Reduced Bolus** / **Super Bolus** toggles add a row), and on some devices the bolus field ends up hidden behind the keyboard while on others it scrolls just enough — it's layout/device-dependent.

## What changed

- Wrapped the Treatments `List` in a `ScrollViewReader`.
- Tagged the Carbs, Fat/Protein, and Bolus input rows with stable `.id`s.
- Added a `.onChange(of: focusedField)` handler that explicitly scrolls the focused row into view (centered, above the keyboard) whenever focus changes.

A short delay before scrolling lets the keyboard's presentation animation begin and the `List` resize its scrollable area first.

Only `Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift` is touched. The line count is mostly re-indentation from adding the `ScrollViewReader` wrapper — review with whitespace hidden to see the real change.

Same change as the one merged into `Build` (#39), retargeted onto `Build-Experiment`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAorz1W7G31FX1WqKau4Ma)_